### PR TITLE
Fix issue caused by different bool not operation on torch.uint8

### DIFF
--- a/code/train.py
+++ b/code/train.py
@@ -75,7 +75,7 @@ def train_one_epoch(options, dataloader, net, optim, epoch, logger, objectives,
         # Bypass lazy way to bypass invalid pixels. 
         invalid_mask = (depth0 == depth0.min()) + (depth0 == depth0.max())
         if obj_mask0 is not None:
-            invalid_mask = ~obj_mask0 + invalid_mask
+            invalid_mask = 1.0 - obj_mask0 + invalid_mask
 
         Rs, ts = net.forward(color0, color1, depth0, depth1, K)[:2]
 


### PR DESCRIPTION
After pytorch 1.3, the not operation for 0 in uint type is 255, instead of 1, causing no grad in loss